### PR TITLE
downgrade ollama model to gemma3:12b-it-qat

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -205,7 +205,7 @@
         },
         "ollama": {
             "base": "http://ollama.lan:11434",
-            "model": "gemma3:27b"
+            "model": "gemma3:12b-it-qat"
         },
         "openai": {
             "model": "gpt-4o-mini",


### PR DESCRIPTION
header speaks for itself. Reason: 27b is a bit slow, and will probably waste resources.
I think we need to iterate a bit here.