### PR TITLE
remove dashes from LLM name

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -205,7 +205,7 @@
         },
         "ollama": {
             "base": "http://ollama.lan:11434",
-            "model": "gemma3:12b-it-qat"
+            "model": "gemma3:12b"
         },
         "openai": {
             "model": "gpt-4o-mini",


### PR DESCRIPTION
seems to be that some bug exists which prevents use of dashes in model names